### PR TITLE
hotfix(#49): fix mocha token err

### DIFF
--- a/.github/workflows/mocha_test.yml
+++ b/.github/workflows/mocha_test.yml
@@ -18,11 +18,14 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
+    
+    - name: create token
+      run: |
+        echo "${{ secrets.TOKEN }}" > ./token
+        # echo TOKEN=${{ secrets.TOKEN }} > .env
+        ls -al
         
     - name: npm install, build, and test
       run: |
-        npm install mocha -g
-        npm install dotenv
+        npm ci
         mocha test.spec.js --exit
-      env:
-        CI: true

--- a/test.spec.js
+++ b/test.spec.js
@@ -4,12 +4,13 @@ const { RTMClient } = require('@slack/rtm-api');
 
 const fs = require('fs');
 
-const channel = 'D047E4D5F0D';
+const channel = 'C04A2C19U31';
 
 let token;
 
 try {
   token = fs.readFileSync('./token').toString('utf-8');
+  token = token.trim();
 } catch (err) {
   console.error(err);
 }


### PR DESCRIPTION
### 작업 개요(#49)
git action에서 mocha test를 돌렸을 때 토큰을 못찾는 에러 수정

<br>

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
<br>

### 작업 상세 내용
mocha test에서 token을 사용할 때 trim()함수를 이용하여 공백이 없도록 처리
git action에 토큰을 제대로 불러오게 git secret key를 사용할 수 있도록 yml파일 수정
<br>

### 함께 생각해볼 문제
토큰을 제대로 불러오지 못했을 때 에러가 발생하고 테스트를 중지 시킬 방법
지금은 토큰을 불러오는지 제대로 찾지 못합니다.
<br>

### 스크린샷(필요한 경우)
다른 팀원들이 동일한 작동을 하는지 확인하기 위함
