### PR TITLE
feature(#69): closed issue and add lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,5 @@
 
 echo "The husky will run automatically."
 
-eslint . --ext .js --fix
+# eslint . --ext .js --fix
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "start": "node index.js"
   },
   "lint-staged": {
-    "*.js": [
-      "eslint . --ext .js --fix"
-    ]
+    "*.js": "eslint --ext .js --fix"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 작업 개요(#69)
pre-commit에 npx lint-staged 명령 추가
<br>

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->
<br>

### 작업 상세 내용
pre-commit 파일에 `npx lint-staged` 추가하여 스테이지 기능 활성화시켰다.
전에 package.json에 추가까지는 했었는데 실행이 안돼서 문제였었다.
그 이유는.. `npm lint-staged`로 실행시켰기 때문..
npm은 모듈 실행기가 아니라 패키지 관리자이며 npx는 모듈 실행기이다.
그러므로 모듈을 실행시킬 때는 npx를 사용해야 한다.
<br>

### 함께 생각해볼 문제
[npm과 npx의 차이 링크](https://velog.io/@kimkyeseung/%EB%B2%88%EC%97%AD-%EA%B7%B8%EB%9E%98-npx-npm%EB%A7%90%EA%B3%A0-%EC%B0%A8%EC%9D%B4%EC%A0%90-%EC%84%A4%EB%AA%85)
<br>

### 스크린샷(필요한 경우)
![image](https://user-images.githubusercontent.com/50980974/205506918-f9fa8350-0e56-4c79-b3ae-1ff3dd65d8d4.png)
