### PR TITLE
release(#2.0.1): add release action and closed #68

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+# main으로 가는 PR이 closed될 때 실행
+on:
+  pull_request:
+    branches:
+      - main
+    types: [ closed ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get branch names
+        id: branch-name
+        uses: tj-actions/branch-names@v4.9
+
+        # release/1.0.0 식인 브랜치이름에서 숫자만 떼서 릴리즈 번호로 사용
+      - name: 버전 정보 추출(from Branch Name)
+        run: echo "TAG=$(echo '${{ steps.branch-name.outputs.current_branch }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')" >> $GITHUB_ENV
+
+      - name: echo current branch name
+        run: echo "current branch name - ${{ env.TAG }}"
+
+      - name: Release & Tag 생성
+        if: github.event.pull_request.merged == true  # PR인 경우에만
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.TAG }}
+          release_name: ${{ env.TAG }}


### PR DESCRIPTION
### 작업 개요(#68)
main에 PR시 release/2.0.1브랜치 명에서 2.0.1을 잘라서 자동 릴리즈

<br>

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [x] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->
<br>

### 작업 상세 내용
main으로 PR시에 <브랜치타입>/<릴리즈번호>의 브랜치명으로 PR하면 자동으로 릴리즈번호를 따서 새 릴리즈를 생성해줍니다.
<br>

### 함께 생각해볼 문제
커밋에 태그를 달아서 번호를 따오는 것보다 브랜치명에서 따오는 것이 우리 브랜치 생성 규칙이랑 더 어울리는 것 같아서 이 방식을 선택했습니다.
<br>

### 스크린샷(필요한 경우)
다른 팀원들이 동일한 작동을 하는지 확인하기 위함
