### PR TITLE
feat(#50): edit prepare-commit-msg and closed #50

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,14 +1,24 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# 표준출력(현재 쉘을 실행한 콘솔이나 터미널)을 변수에 저장 
+# shell에서 입력받은 argument를 저장
 COMMIT_MESSAGE_FILE_PATH=$1
+COMMIT_SOURCE=$2
+COMMIT_AMEND=$3
 
-# TODO merge 할 때도 생성되니까 그 부분 삭제할 수 있도록
+# merge 할 때 type/issue 다시 생성되지 않게 함
+if [ "${COMMIT_SOURCE}" = merge ];then
+    exit 0
+fi
+
+# amend 할 때 type/issue 다시 생성되지 않게 함
+if [ "${COMMIT_AMEND}" = HEAD ];then
+    exit 0
+fi
 
 # grep으로 현재 브랜치 긁어오고 sed로 자름
 TYPE=$(git branch | grep '*' | sed 's/* //' | sed 's/\([^/]*\).*/\1/')
-# ISSUENUMBER=$(git branch | grep '\*' | sed 's/* //' | sed 's/^.*\///' | sed 's/^\([^-]*-[^-]*\).*/\1/')
 ISSUENUMBER=$(git branch | grep '*' | sed 's/* //' | sed 's/^.*\///')
+
 echo "$TYPE(#$ISSUENUMBER): $(cat "$COMMIT_MESSAGE_FILE_PATH")" > "$COMMIT_MESSAGE_FILE_PATH"
 echo "$(cat .gitmessage.txt)" >> "$COMMIT_MESSAGE_FILE_PATH"


### PR DESCRIPTION
### 작업 개요(#이슈번호)
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->
merge, amend시에도 type/issue 자동생성되던 것 막음

<br>

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->
<br>

### 작업 상세 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
- 'git merge'이렇게 2번째 argument에 merge가 들어오면 merge commit에 type/issue가 다시 생성되지 않게 한다.
- 'git commit --amend' 이렇게 들어올 때는 --amend가 HEAD로 나타나는데, 아마 amend가 전에 커밋을 변경하는 거라 쉘에서는 바로 HEAD로 입력되는 듯 하다. 그래서 HEAD와 비교해주었다.
- merge는 if 문 써주기 전에도 밑에 gitmessage부분이 생겼다 안생겼다해서 정확히 확인이 안 된다.
- amend는 확실히 확인했다. 정상 작동한다.
<br>

### 함께 생각해볼 문제
<!--
  ex) 
  1. 테스트를 매번 작성하기 귀찮은데 줄일 방법이 있을까요?
  2. 이 부분 로직을 ~식으로 변경하고 싶은데 어떤 방법이 있을까요?
-->
추가적으로 prepare-commit-msg에 필요한 사항이 있을까요??
<br>

### 스크린샷(필요한 경우)
다른 팀원들이 동일한 작동을 하는지 확인하기 위함
