### PR TITLE
feat(#67): push된 기능에 대해서만 mocha test 진행

### DIFF
--- a/.github/workflows/mocha_test.yml
+++ b/.github/workflows/mocha_test.yml
@@ -14,22 +14,32 @@ jobs:
         node-version: [18.x]
 
     steps:
-    - uses: actions/checkout@v1
-    
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
+      - uses: actions/checkout@v1
 
-    - name: create token
-      run: |
-        echo "${{ secrets.TOKEN }}" > ./token
-        ls -al
-        
-    - name: npm install, build, and test
-      run: |
-        npm ci
-        npm install mocha -g
-        mocha test.spec.js --timeout 10000 --exit 
-      env:
-        CI: true
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: create token
+        run: |
+          echo "${{ secrets.TOKEN }}" > ./token
+          ls -al
+
+      - name: npm install, build, and test greeting
+        if: github.event_path == 'greeting.js'
+        run: |
+          npm ci
+          npm install mocha -g
+          mocha test_greeting.js --timeout 10000 --exit
+        env:
+          CI: true
+
+      - name: npm install, build, and test lunch
+        if: github.event_path == 'lunch.js'
+        run: |
+          npm ci
+          npm install mocha -g
+          mocha test_lunch.js --timeout 10000 --exit
+        env:
+          CI: true

--- a/.github/workflows/mocha_test.yml
+++ b/.github/workflows/mocha_test.yml
@@ -16,6 +16,21 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            pathGreeting:
+              - 'greeting.js'
+            pathSquare:
+              - 'square.js'
+            pathLunch:
+              - 'lunch.js'
+            pathWeeklunch:
+              - 'weeklunch.js'
+            pathDepartment:
+              - 'department.js'
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
@@ -26,20 +41,52 @@ jobs:
           echo "${{ secrets.TOKEN }}" > ./token
           ls -al
 
-      - name: npm install, build, and test greeting
-        if: github.event_path == 'greeting.js'
+      # push된 파일이 greeting.js일 경우 test_greeting.js 실행
+      - name: npm install, build, and test greeting.js
+        if: steps.filter.outputs.pathGreeting == 'true'
         run: |
           npm ci
           npm install mocha -g
-          mocha test_greeting.js --timeout 10000 --exit
+          mocha test_spec/test_greeting.js --timeout 10000 --exit
         env:
           CI: true
 
-      - name: npm install, build, and test lunch
-        if: github.event_path == 'lunch.js'
+      # push된 파일이 square.js일 경우 test_square.js 실행
+      - name: npm install, build, and test square.js
+        if: steps.filter.outputs.pathSquare == 'true'
         run: |
           npm ci
           npm install mocha -g
-          mocha test_lunch.js --timeout 10000 --exit
+          mocha test_spec/test_square.js --timeout 10000 --exit
+        env:
+          CI: true
+
+      # push된 파일이 lunch.js일 경우 test_lunch.js 실행
+      - name: npm install, build, and test lunch.js
+        if: steps.filter.outputs.pathLunch == 'true'
+        run: |
+          npm ci
+          npm install mocha -g
+          mocha test_spec/test_lunch.js --timeout 10000 --exit
+        env:
+          CI: true
+
+      # push된 파일이 weeklunch.js일 경우 test_weeklunch.js 실행
+      - name: npm install, build, and test weeklunch.js
+        if: steps.filter.outputs.pathWeeklunch == 'true'
+        run: |
+          npm ci
+          npm install mocha -g
+          mocha test_spec/test_weeklunch.js --timeout 10000 --exit
+        env:
+          CI: true
+
+      # push된 파일이 department.js일 경우 test_department.js 실행
+      - name: npm install, build, and test department.js
+        if: steps.filter.outputs.pathDepartment == 'true'
+        run: |
+          npm ci
+          npm install mocha -g
+          mocha test_spec/test_department.js --timeout 10000 --exit
         env:
           CI: true


### PR DESCRIPTION
### 작업 개요(#67)
push 시, 수정된 파일만 mocha test를 진행한다.
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->

<br>

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->
<br>

### 작업 상세 내용
push시 변경된 파일에 대해서만 mocha test를 실행시키기 위해 ```dorny/paths-filter@v2```사용하였다.

dorny/paths-filter@v2
: push시 base branch와 비교하여 파일의 변경을 감지해준다. 

```dorny/paths-filter@v2```를 이용해 각 기능 파일(lunch.js, greeting.js ....)에 대한 경로를 저장해놓았다.
pathgreeting: greeting.js 경로 저장
pathSquare: square.js 경로 저장
pathLunch: lunch.js 경로 저장
pathWeeklunch: weeklunch.js 경로 저장
pathDepartment: department.js 경로 저장

push시 경로를 저장해 놓은 파일의 변경을 감지하고, 변경 된 파일에 대한 mocha test를 실행한다.
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
<br>

### 함께 생각해볼 문제
* 예) lunch.js 수정 후 푸쉬하여 lunch.js에 대한 모카테스트가 진행된다. 그 후 greeting.js 수정 후 푸쉬하면 lunch.js와 greeting.js에 대한 모카테스트가 모두 진행된다. dev에는 수정된 lunch.js가 반영되어 있지 않아 이런 현상이 발생하는 것 같습니다..
dorny/paths-filter@v2를 이용하지 않고, push된 기능에 대해서만 mocha test 진행할 수 있도록 하는 방법이 있을까요?
* department.js 푸쉬를 하지 않았음에도 department.js가 변경되었다고 판단 후, department.js에 대한 모카 테스트를 진행합니다. 문제를 찾으려 살펴보았으나 찾지 못하였습니다.. 이에 대한 해결이 필요합니다.
<!--
  ex) 
  1. 테스트를 매번 작성하기 귀찮은데 줄일 방법이 있을까요?
  2. 이 부분 로직을 ~식으로 변경하고 싶은데 어떤 방법이 있을까요?
-->
<br>

### 스크린샷(필요한 경우)
다른 팀원들이 동일한 작동을 하는지 확인하기 위함
